### PR TITLE
release: prepare 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,36 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## 1.0.0 - 2026-04-09
+
+Changes on `origin/master` since `v0.10.2` (2023-12-23).
+
+### Breaking Changes
+
+- Node.js 22 is now required across the monorepo. Node 20 and older are no longer supported.
+- `fastify` is no longer installed as a direct dependency of `@spencejs/spence`; consumers must provide their own compatible Fastify version.
+- Fastify integration packages now declare Fastify as a peer dependency with support for Fastify 4 or 5, which may require consumer dependency updates.
+- `@spencejs/spence-mongo-repos` now expects MongoDB as a peer dependency with support for MongoDB 6 or 7.
+- `@spencejs/spence-pg-repos` now expects `pg` and `knex` as peer dependencies instead of bundling them as runtime dependencies.
+- `spence-api` update routes now fail configuration unless both `updateSchema` and `replySchema` are provided.
+
+### Changed
+
+- Require Node.js 22 or newer across the monorepo and add a root `.nvmrc`.
+- Migrate CI from CircleCI to GitHub Actions with a peer-dependency matrix for supported integrations.
+- Move key integrations to peer dependencies where appropriate, including Fastify, MongoDB, `pg`, and `knex`.
+- Expand compatibility to Fastify 4 and 5, MongoDB 6 and 7, and `pg` 8.
+
+### Fixed
+
+- Align `spence-api` REST validation and tests with Fastify v5 behavior.
+- Tighten `findMany` query schemas so `limit` and `offset` are typed as non-negative integers.
+- Fail `update` route registration unless both `updateSchema` and `replySchema` are provided.
+- Forward controller extension boot errors through `next` instead of throwing synchronously.
+- Clarify the current `PATCH` update semantics in the `spence-api` README.
+
+### Dependencies
+
+- Refresh runtime and toolchain dependencies across workspaces, including Fastify 5.8.3, `fastify-plugin` 5.1.0, `pg` 8.19.0, `pg-types` 4.1.0, MongoDB 7, Pino 10, UUID 11, Jest 30, TypeScript 5.9, and Prettier 3.8.
+- Update supporting packages such as Lodash, Handlebars, Axios, `env-var`, `http-errors`, and related type definitions.

--- a/lerna.json
+++ b/lerna.json
@@ -3,5 +3,5 @@
     "packages/*"
   ],
   "npmClient": "yarn",
-  "version": "0.10.2"
+  "version": "1.0.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
   {
   "name": "spence",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "private": true,
   "dependencies": {},
   "engines": {

--- a/packages/spence-api/package.json
+++ b/packages/spence-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence-api",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "./src/index.js",
   "types": "types/index.d.ts",
   "license": "MIT",
@@ -11,7 +11,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@spencejs/spence-events": "^0.10.2",
+    "@spencejs/spence-events": "^1.0.0",
     "fastify-plugin": "^5.1.0",
     "http-errors": "^2.0.0",
     "lodash": "^4.18.1"
@@ -20,9 +20,9 @@
     "fastify": "^4.0.0 || ^5.0.0"
   },
   "devDependencies": {
-    "@spencejs/spence-config": "^0.10.2",
-    "@spencejs/spence-mongo-repos": "^0.10.2",
-    "@spencejs/spence-pg-repos": "^0.10.2",
+    "@spencejs/spence-config": "^1.0.0",
+    "@spencejs/spence-mongo-repos": "^1.0.0",
+    "@spencejs/spence-pg-repos": "^1.0.0",
     "@types/lodash": "~4.17.4",
     "@types/node": "~25.3.1",
     "await-sleep": "~0.0.1",

--- a/packages/spence-config/package.json
+++ b/packages/spence-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence-config",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "license": "MIT",

--- a/packages/spence-events/package.json
+++ b/packages/spence-events/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence-events",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "src/index.js",
   "types": "types/index.d.ts",
   "license": "MIT",
@@ -15,7 +15,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@spencejs/spence-config": "^0.10.2",
+    "@spencejs/spence-config": "^1.0.0",
     "@types/lodash": "~4.17.4",
     "@types/node": "~25.3.1",
     "@types/uuid": "^10.0.0",

--- a/packages/spence-factories/package.json
+++ b/packages/spence-factories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence-factories",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "src/factory.js",
   "license": "MIT",
   "engines": {
@@ -11,9 +11,9 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@spencejs/spence-config": "^0.10.2",
-    "@spencejs/spence-mongo-repos": "^0.10.2",
-    "@spencejs/spence-pg-repos": "^0.10.2",
+    "@spencejs/spence-config": "^1.0.0",
+    "@spencejs/spence-mongo-repos": "^1.0.0",
+    "@spencejs/spence-pg-repos": "^1.0.0",
     "@types/lodash": "^4.14.149",
     "@types/node": "~25.3.1",
     "eslint": "~8.57.0",

--- a/packages/spence-mongo-repos/package.json
+++ b/packages/spence-mongo-repos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence-mongo-repos",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",
   "license": "MIT",
@@ -11,13 +11,13 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@spencejs/spence-events": "^0.10.2",
+    "@spencejs/spence-events": "^1.0.0",
     "fastify-plugin": "^5.1.0",
     "http-errors": "^2.0.0",
     "lodash": "^4.18.1"
   },
   "devDependencies": {
-    "@spencejs/spence-config": "^0.10.2",
+    "@spencejs/spence-config": "^1.0.0",
     "@types/http-errors": "^2.0.1",
     "@types/lodash": "~4.17.4",
     "@types/node": "~25.3.1",

--- a/packages/spence-pg-repos/package.json
+++ b/packages/spence-pg-repos/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence-pg-repos",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "./src/index.js",
   "license": "MIT",
   "publishConfig": {
@@ -10,7 +10,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@spencejs/spence-events": "^0.10.2",
+    "@spencejs/spence-events": "^1.0.0",
     "fastify-plugin": "^5.1.0",
     "http-errors": "^2.0.0",
     "lodash": "^4.18.1",
@@ -19,7 +19,7 @@
     "uuid": "^11.1.0"
   },
   "devDependencies": {
-    "@spencejs/spence-config": "^0.10.2",
+    "@spencejs/spence-config": "^1.0.0",
     "@types/lodash": "~4.17.4",
     "@types/node": "~25.3.1",
     "await-sleep": "~0.0.1",

--- a/packages/spence/package.json
+++ b/packages/spence/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@spencejs/spence",
-  "version": "0.10.2",
+  "version": "1.0.0",
   "main": "./src/index.js",
   "license": "MIT",
   "publishConfig": {
@@ -10,8 +10,8 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "@spencejs/spence-api": "^0.10.2",
-    "@spencejs/spence-events": "^0.10.2"
+    "@spencejs/spence-api": "^1.0.0",
+    "@spencejs/spence-events": "^1.0.0"
   },
   "peerDependencies": {
     "fastify": "^4.0.0 || ^5.0.0"


### PR DESCRIPTION
## Summary
- add the 1.0.0 changelog entry with breaking changes called out
- bump lerna and workspace package versions from 0.10.2 to 1.0.0
- update internal workspace dependency ranges to 1.0.0

## Notes
- remote master is protected, so this release prep is coming through a PR
- remote tag v1.0.0 has already been pushed for the release commit

## Testing
- not run (release metadata and changelog only)