### PR TITLE
fix: replace direct uuid usage with node crypto

### DIFF
--- a/packages/spence-events/package.json
+++ b/packages/spence-events/package.json
@@ -11,14 +11,12 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "lodash": "^4.18.1",
-    "uuid": "^11.1.0"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "@spencejs/spence-config": "^1.0.0",
     "@types/lodash": "~4.17.4",
     "@types/node": "~25.6.0",
-    "@types/uuid": "^10.0.0",
     "await-sleep": "~0.0.1",
     "eslint": "8.57.1",
     "eslint-config-airbnb-base": "~15.0.0",

--- a/packages/spence-events/src/events.js
+++ b/packages/spence-events/src/events.js
@@ -1,6 +1,6 @@
 const _ = require("lodash/fp");
 const { EventEmitter } = require("events");
-const { v1: idGenerator } = require("uuid");
+const { randomUUID: idGenerator } = require("node:crypto");
 
 const nexus = new EventEmitter();
 let connectedChannels = ["*"];

--- a/packages/spence-events/test/events.test.js
+++ b/packages/spence-events/test/events.test.js
@@ -1,4 +1,4 @@
-const { v1: uuidv1 } = require("uuid");
+const { randomUUID } = require("node:crypto");
 const { env } = require("@spencejs/spence-config");
 const { publish, subscribe, disconnect, connect, setErrorHandler } = require("../src/events");
 const { UUID_FORMAT } = require("../../spence-api/test/helpers/regexes");
@@ -14,7 +14,7 @@ describe("events", () => {
   });
 
   it("publishing without any subscribers is fine", async () => {
-    const result = await publish(`simple`, `created`, { aVal: "test" }, { userId: uuidv1() });
+    const result = await publish(`simple`, `created`, { aVal: "test" }, { userId: randomUUID() });
     expect(result).toEqual(undefined);
     expect(errorHandler).not.toHaveBeenCalled();
   });
@@ -24,7 +24,7 @@ describe("events", () => {
     subscribe(`simple`, `created`, subscribers[1]);
     subscribe(`simple`, `created`, subscribers[2]);
     const payload = { aVal: "test" };
-    const context = { userId: uuidv1(), source: env.source };
+    const context = { userId: randomUUID(), source: env.source };
     const result = await publish(`simple`, `created`, payload, context);
     expect(result).toEqual(undefined);
     expect(errorHandler).not.toHaveBeenCalled();
@@ -65,7 +65,7 @@ describe("events", () => {
     });
     subscribe(`simple`, `created`, subscriber);
     const payload = { aVal: "test" };
-    const context = { userId: uuidv1(), source: env.source };
+    const context = { userId: randomUUID(), source: env.source };
     const result = await publish(`simple`, `created`, payload, context);
     expect(result).toEqual(undefined);
     expect(errorHandler).toHaveBeenCalledWith(
@@ -98,7 +98,7 @@ describe("events", () => {
     const subscriber = jest.fn();
     subscribe(`simple`, `created`, subscriber);
     const payload = { aVal: "test" };
-    const context = { userId: uuidv1() };
+    const context = { userId: randomUUID() };
     const result = await publish(`simple`, `created`, payload, context);
     expect(result).toEqual(undefined);
     expect(errorHandler).not.toHaveBeenCalled();
@@ -110,7 +110,7 @@ describe("events", () => {
     const subscriber = jest.fn();
     subscribe(`simple`, `created`, subscriber);
     const payload = { aVal: "test" };
-    const context = { userId: uuidv1(), source: env.source };
+    const context = { userId: randomUUID(), source: env.source };
     const result = await publish(`simple`, `created`, payload, context);
     expect(result).toEqual(undefined);
     expect(errorHandler).not.toHaveBeenCalled();
@@ -132,7 +132,7 @@ describe("events", () => {
     const subscriber = jest.fn();
     subscribe(`simple`, `created`, subscriber);
     const payload = { aVal: "test" };
-    const context = { userId: uuidv1(), source: env.source };
+    const context = { userId: randomUUID(), source: env.source };
     const result = await publish(`simple`, `created`, payload, context);
     expect(result).toEqual(undefined);
     expect(errorHandler).not.toHaveBeenCalled();

--- a/packages/spence-factories/package.json
+++ b/packages/spence-factories/package.json
@@ -7,8 +7,7 @@
     "node": ">=22.0.0"
   },
   "dependencies": {
-    "lodash": "^4.18.1",
-    "uuid": "^11.1.0"
+    "lodash": "^4.18.1"
   },
   "devDependencies": {
     "@spencejs/spence-config": "^1.0.0",

--- a/packages/spence-factories/src/factory.js
+++ b/packages/spence-factories/src/factory.js
@@ -1,5 +1,5 @@
 const _ = require("lodash/fp");
-const { v1: uuidv1 } = require("uuid");
+const { randomUUID } = require("node:crypto");
 
 function register(name, ...args) {
   let defaultRepo;
@@ -59,7 +59,7 @@ function createdFactoryType(commonFactory) {
   return async (overrides = {}) => {
     const { item, repo } = await commonFactory("created")(overrides);
     const idKey = _.getOr("id", "collection.idKey", repo);
-    const mockIdGenerator = _.getOr(uuidv1, "collection.mockIdGenerator", repo);
+    const mockIdGenerator = _.getOr(randomUUID, "collection.mockIdGenerator", repo);
     const timestampKeys = _.getOr({ createdAt: "createdAt", updatedAt: "updatedAt" }, "collection.timestampKeys", repo);
     return {
       [idKey]: mockIdGenerator(),

--- a/packages/spence-factories/test/factory.test.js
+++ b/packages/spence-factories/test/factory.test.js
@@ -1,5 +1,5 @@
 const _ = require("lodash/fp");
-const { v1: uuidv1 } = require("uuid");
+const { randomUUID } = require("node:crypto");
 const { log, env } = require("@spencejs/spence-config");
 const {
   knexFactory,
@@ -225,7 +225,7 @@ describe("test pg factories", () => {
       complexFactory = register("complex", async (overrides, { getOrBuild }) => {
         const simpleVal = await getOrBuild("simpleVal", _.noop);
         const simple = await getOrBuild("simple", simpleFactory, { aVal: simpleVal });
-        const aComplexVal = await getOrBuild("aComplexVal", uuidv1);
+        const aComplexVal = await getOrBuild("aComplexVal", randomUUID);
         return {
           item: {
             aComplexVal,
@@ -277,7 +277,7 @@ describe("test pg factories", () => {
 
     it("if already persisted it only persist the complex", async () => {
       const { persistComplex } = complexFactory;
-      const simpleId = uuidv1();
+      const simpleId = randomUUID();
       expect(await persistComplex({ simple: { id: simpleId } })).toEqual({
         id: expect.stringMatching(UUID_FORMAT),
         aComplexVal: expect.stringMatching(UUID_FORMAT),

--- a/packages/spence-mongo-repos/package.json
+++ b/packages/spence-mongo-repos/package.json
@@ -33,8 +33,7 @@
     "pino-pretty": "~13.1.1",
     "prettier": "~3.8.0",
     "shortid": "^2.2.15",
-    "typescript": "~6.0.3",
-    "uuid": "~11.1.0"
+    "typescript": "~6.0.3"
   },
   "peerDependencies": {
     "mongodb": "^6.0.0 || ^7.0.0"

--- a/packages/spence-pg-repos/package.json
+++ b/packages/spence-pg-repos/package.json
@@ -15,8 +15,7 @@
     "http-errors": "^2.0.0",
     "lodash": "^4.18.1",
     "p-settle": "^4.0.1",
-    "pg-types": "^4.1.0",
-    "uuid": "^11.1.0"
+    "pg-types": "^4.1.0"
   },
   "devDependencies": {
     "@spencejs/spence-config": "^1.0.0",

--- a/packages/spence-pg-repos/src/tables/table.js
+++ b/packages/spence-pg-repos/src/tables/table.js
@@ -1,5 +1,5 @@
 const _ = require("lodash/fp");
-const { v4: uuidv4 } = require("uuid");
+const { randomUUID } = require("node:crypto");
 
 const { knexPromise } = require("../knex");
 
@@ -56,7 +56,7 @@ function init(
     connection,
     transformCase,
     timestampKeys,
-    mockIdGenerator: uuidv4,
+    mockIdGenerator: randomUUID,
   });
   Object.defineProperty(table, "columnInfo", {
     get() {

--- a/packages/spence-pg-repos/test/pg-repos-registry.test.js
+++ b/packages/spence-pg-repos/test/pg-repos-registry.test.js
@@ -1,5 +1,5 @@
 const _ = require("lodash/fp");
-const { v1: uuidv1 } = require("uuid");
+const { randomUUID } = require("node:crypto");
 const { log, env } = require("@spencejs/spence-config");
 const { knex, knexFactory } = require("../src/knex");
 const { createSchema, dropSchema } = require("../src/tables/schemas");
@@ -62,14 +62,14 @@ describe("pg table registry", () => {
     const contexts = [{ foo: "1" }, { foo: "2" }, { foo: "3" }];
     const registeredTablesArray = _.map(addContext, contexts);
     const results = await Promise.all(
-      _.map((tables) => tables.simples.insert({ id: uuidv1(), aVal: "foo" }), registeredTablesArray),
+      _.map((tables) => tables.simples.insert({ id: randomUUID(), aVal: "foo" }), registeredTablesArray),
     );
 
     expect(results).toHaveLength(3);
 
     expect(_.map("simples.callCounterRef.current", registeredTablesArray)).toEqual([1, 1, 1]);
     expect(_.map("simples.contextRef.current", registeredTablesArray)).toEqual(contexts);
-    registeredTablesArray[0].simples.insert({ id: uuidv1(), aVal: "foo" });
+    registeredTablesArray[0].simples.insert({ id: randomUUID(), aVal: "foo" });
     expect(_.map("simples.callCounterRef.current", registeredTablesArray)).toEqual([2, 1, 1]);
     expect(_.map("simples.contextRef.current", registeredTablesArray)).toEqual(contexts);
   });

--- a/packages/spence-pg-repos/test/pg-repos-registry.test.js
+++ b/packages/spence-pg-repos/test/pg-repos-registry.test.js
@@ -69,7 +69,7 @@ describe("pg table registry", () => {
 
     expect(_.map("simples.callCounterRef.current", registeredTablesArray)).toEqual([1, 1, 1]);
     expect(_.map("simples.contextRef.current", registeredTablesArray)).toEqual(contexts);
-    registeredTablesArray[0].simples.insert({ id: randomUUID(), aVal: "foo" });
+    await registeredTablesArray[0].simples.insert({ id: randomUUID(), aVal: "foo" });
     expect(_.map("simples.callCounterRef.current", registeredTablesArray)).toEqual([2, 1, 1]);
     expect(_.map("simples.contextRef.current", registeredTablesArray)).toEqual(contexts);
   });

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -1,5 +1,5 @@
 const _ = require("lodash/fp");
-const { v1: uuidv1 } = require("uuid");
+const { randomUUID } = require("node:crypto");
 const { log, env } = require("@spencejs/spence-config");
 const { knex, knexFactory } = require("../src/knex");
 const { createSchema, dropSchema } = require("../src/tables/schemas");
@@ -80,7 +80,7 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
     });
 
     it("should be able to insertMany", async () => {
-      const val = () => ({ id: uuidv1(), aVal: "foo" });
+      const val = () => ({ id: randomUUID(), aVal: "foo" });
       const vals = [val(), val(), val()];
       const result = await wrap(async (context) => simpleTable(context).insertMany(vals));
       const findResults = await simpleTable().find().whereIn("id", _.map("id", vals));
@@ -110,7 +110,7 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
     });
 
     it("should be able to count", async () => {
-      const val = () => ({ id: uuidv1(), aVal: "foo" });
+      const val = () => ({ id: randomUUID(), aVal: "foo" });
       const vals = [val(), val(), val()];
 
       const result = await wrap(async (context) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1791,11 +1791,6 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.3.tgz#6209321eb2c1712a7e7466422b8cb1fc0d9dd5d8"
   integrity sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==
 
-"@types/uuid@^10.0.0":
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-10.0.0.tgz#e9c07fe50da0f53dc24970cca94d619ff03f6f6d"
-  integrity sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==
-
 "@types/webidl-conversions@*":
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/@types/webidl-conversions/-/webidl-conversions-7.0.3.tgz#1306dbfa53768bcbcfc95a1c8cde367975581859"
@@ -8684,11 +8679,6 @@ util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==
-
-uuid@^11.1.0, uuid@~11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.0.tgz#9549028be1753bb934fc96e2bca09bb4105ae912"
-  integrity sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==
 
 uuid@^8.3.2:
   version "8.3.2"


### PR DESCRIPTION
## Summary
- replace direct CommonJS `uuid` usage with Node's built-in `crypto.randomUUID()`
- remove now-unused direct `uuid` dependencies from the affected workspace packages
- regenerate `yarn.lock` to reflect the dependency cleanup

## Why
`uuid@14` no longer supports the existing `require("uuid")` usage in these CommonJS packages. This keeps the repo compatible with the Node 22 runtime already required by the monorepo.

## Testing
- `yarn install`
- `node -e "require('/Users/andresolave/Projects/spencer/packages/spence-events/src/events'); require('/Users/andresolave/Projects/spencer/packages/spence-factories/src/factory'); require('/Users/andresolave/Projects/spencer/packages/spence-pg-repos/src/tables/table'); console.log('smoke-ok')"`
- `yarn test --watchman=false --runTestsByPath packages/spence-events/test/events.test.js`

## Context
This addresses the runtime break behind the `uuid` dependency bump work in #1084.