### PR TITLE
[codex] Drop p-settle from spence-pg-repos

### DIFF
--- a/packages/spence-pg-repos/package.json
+++ b/packages/spence-pg-repos/package.json
@@ -14,7 +14,6 @@
     "fastify-plugin": "^5.1.0",
     "http-errors": "^2.0.0",
     "lodash": "^4.18.1",
-    "p-settle": "^4.0.1",
     "pg-types": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/spence-pg-repos/src/repos/index.js
+++ b/packages/spence-pg-repos/src/repos/index.js
@@ -1,7 +1,6 @@
 /* eslint-disable max-lines */
 const _ = require("lodash/fp");
 const newError = require("http-errors");
-const pSettle = require("p-settle");
 const { publish } = require("@spencejs/spence-events");
 const initPrepModification = require("./prep-modification");
 const { dbifyColumn, apifyColumn } = require("../knex/transformations");
@@ -14,6 +13,14 @@ function renderArrayRemoveValue(value) {
     return `"${value}"`;
   }
   return value;
+}
+
+function normalizeSettledResult(result) {
+  if (result.status === "fulfilled") {
+    return { isFulfilled: true, isRejected: false, value: result.value };
+  }
+
+  return { isFulfilled: false, isRejected: true, reason: result.reason };
 }
 
 function init(table, extensions = []) {
@@ -89,7 +96,9 @@ function init(table, extensions = []) {
     }
 
     function insertMany(vals, selection) {
-      return pSettle(_.map((val) => applied.insert(val, selection), vals));
+      return Promise.allSettled(_.map((val) => applied.insert(val, selection), vals)).then(
+        _.map(normalizeSettledResult),
+      );
     }
 
     async function findOrInsert(val, naturalKey, returning = applied.defaultColumnsSelection) {

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -91,11 +91,11 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
 
     if (!transactions) {
       it("should include rejected results when insertMany cannot insert every value", async () => {
-        const duplicateId = uuidv1();
+        const duplicateId = randomUUID();
         const vals = [
           { id: duplicateId, aVal: "first" },
           { id: duplicateId, aVal: "duplicate" },
-          { id: uuidv1(), aVal: "insertMany-success" },
+          { id: randomUUID(), aVal: "insertMany-success" },
         ];
 
         const result = await simpleTable().insertMany(vals);

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -85,10 +85,42 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
       const result = await wrap(async (context) => simpleTable(context).insertMany(vals));
       const findResults = await simpleTable().find().whereIn("id", _.map("id", vals));
       const expected = _.map((v) => ({ ...v, createdAt: expect.any(Date) }), vals);
-      expect(result).toEqual(
-        _.map((value) => ({ isFulfilled: true, isRejected: false, value }), expected),
-      );
+      expect(result).toEqual(_.map((value) => ({ isFulfilled: true, isRejected: false, value }), expected));
       expect(_.sortBy("id", findResults)).toEqual(_.sortBy("id", expected));
+    });
+
+    it("should include rejected results when insertMany cannot insert every value", async () => {
+      const duplicateId = uuidv1();
+      const vals = [
+        { id: duplicateId, aVal: "first" },
+        { id: duplicateId, aVal: "duplicate" },
+        { id: uuidv1(), aVal: "unique" },
+      ];
+
+      const result = await simpleTable().insertMany(vals);
+      const fulfilled = result.filter(({ isFulfilled }) => isFulfilled);
+      const rejected = result.filter(({ isRejected }) => isRejected);
+      const findResults = await simpleTable().find().whereIn("id", [duplicateId, vals[2].id]);
+
+      expect(fulfilled).toHaveLength(2);
+      expect(rejected).toHaveLength(1);
+      expect(rejected[0]).toEqual({
+        isFulfilled: false,
+        isRejected: true,
+        reason: expect.any(Error),
+      });
+      expect(_.sortBy("id", _.map("value", fulfilled))).toEqual(
+        _.sortBy("id", [
+          { id: duplicateId, aVal: expect.any(String), createdAt: expect.any(Date) },
+          { ...vals[2], createdAt: expect.any(Date) },
+        ]),
+      );
+      expect(_.sortBy("id", findResults)).toEqual(
+        _.sortBy("id", [
+          { id: duplicateId, aVal: expect.any(String), createdAt: expect.any(Date) },
+          { ...vals[2], createdAt: expect.any(Date) },
+        ]),
+      );
     });
 
     it("should be able to find by id", async () => {

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -89,39 +89,42 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
       expect(_.sortBy("id", findResults)).toEqual(_.sortBy("id", expected));
     });
 
-    it("should include rejected results when insertMany cannot insert every value", async () => {
-      const duplicateId = uuidv1();
-      const vals = [
-        { id: duplicateId, aVal: "first" },
-        { id: duplicateId, aVal: "duplicate" },
-        { id: uuidv1(), aVal: "insertMany-success" },
-      ];
+    (transactions ? it.skip : it)(
+      "should include rejected results when insertMany cannot insert every value",
+      async () => {
+        const duplicateId = uuidv1();
+        const vals = [
+          { id: duplicateId, aVal: "first" },
+          { id: duplicateId, aVal: "duplicate" },
+          { id: uuidv1(), aVal: "insertMany-success" },
+        ];
 
-      const result = await simpleTable().insertMany(vals);
-      const fulfilled = result.filter(({ isFulfilled }) => isFulfilled);
-      const rejected = result.filter(({ isRejected }) => isRejected);
-      const findResults = await simpleTable().find().whereIn("id", [duplicateId, vals[2].id]);
+        const result = await simpleTable().insertMany(vals);
+        const fulfilled = result.filter(({ isFulfilled }) => isFulfilled);
+        const rejected = result.filter(({ isRejected }) => isRejected);
+        const findResults = await simpleTable().find().whereIn("id", [duplicateId, vals[2].id]);
 
-      expect(fulfilled).toHaveLength(2);
-      expect(rejected).toHaveLength(1);
-      expect(rejected[0]).toEqual({
-        isFulfilled: false,
-        isRejected: true,
-        reason: expect.any(Error),
-      });
-      expect(_.sortBy("id", _.map("value", fulfilled))).toEqual(
-        _.sortBy("id", [
-          { id: duplicateId, aVal: expect.any(String), createdAt: expect.any(Date) },
-          { ...vals[2], createdAt: expect.any(Date) },
-        ]),
-      );
-      expect(_.sortBy("id", findResults)).toEqual(
-        _.sortBy("id", [
-          { id: duplicateId, aVal: expect.any(String), createdAt: expect.any(Date) },
-          { ...vals[2], createdAt: expect.any(Date) },
-        ]),
-      );
-    });
+        expect(fulfilled).toHaveLength(2);
+        expect(rejected).toHaveLength(1);
+        expect(rejected[0]).toEqual({
+          isFulfilled: false,
+          isRejected: true,
+          reason: expect.any(Error),
+        });
+        expect(_.sortBy("id", _.map("value", fulfilled))).toEqual(
+          _.sortBy("id", [
+            { id: duplicateId, aVal: expect.any(String), createdAt: expect.any(Date) },
+            { ...vals[2], createdAt: expect.any(Date) },
+          ]),
+        );
+        expect(_.sortBy("id", findResults)).toEqual(
+          _.sortBy("id", [
+            { id: duplicateId, aVal: expect.any(String), createdAt: expect.any(Date) },
+            { ...vals[2], createdAt: expect.any(Date) },
+          ]),
+        );
+      },
+    );
 
     it("should be able to find by id", async () => {
       const val = { id: Date.now().toString(), aVal: "foo" };

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -85,7 +85,9 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
       const result = await wrap(async (context) => simpleTable(context).insertMany(vals));
       const findResults = await simpleTable().find().whereIn("id", _.map("id", vals));
       const expected = _.map((v) => ({ ...v, createdAt: expect.any(Date) }), vals);
-      expect(_.map("value", result)).toEqual(expected);
+      expect(result).toEqual(
+        _.map((value) => ({ isFulfilled: true, isRejected: false, value }), expected),
+      );
       expect(_.sortBy("id", findResults)).toEqual(_.sortBy("id", expected));
     });
 

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -89,9 +89,8 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
       expect(_.sortBy("id", findResults)).toEqual(_.sortBy("id", expected));
     });
 
-    (transactions ? it.skip : it)(
-      "should include rejected results when insertMany cannot insert every value",
-      async () => {
+    if (!transactions) {
+      it("should include rejected results when insertMany cannot insert every value", async () => {
         const duplicateId = uuidv1();
         const vals = [
           { id: duplicateId, aVal: "first" },
@@ -123,8 +122,8 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
             { ...vals[2], createdAt: expect.any(Date) },
           ]),
         );
-      },
-    );
+      });
+    }
 
     it("should be able to find by id", async () => {
       const val = { id: Date.now().toString(), aVal: "foo" };

--- a/packages/spence-pg-repos/test/pg-repos.test.js
+++ b/packages/spence-pg-repos/test/pg-repos.test.js
@@ -94,7 +94,7 @@ describe.each([[{ columnCase: "snake", transactions: false }], [{ columnCase: "c
       const vals = [
         { id: duplicateId, aVal: "first" },
         { id: duplicateId, aVal: "duplicate" },
-        { id: uuidv1(), aVal: "unique" },
+        { id: uuidv1(), aVal: "insertMany-success" },
       ];
 
       const result = await simpleTable().insertMany(vals);

--- a/yarn.lock
+++ b/yarn.lock
@@ -6698,7 +6698,7 @@ p-limit@^1.1.0:
   dependencies:
     p-try "^1.0.0"
 
-p-limit@^2.2.0, p-limit@^2.2.2:
+p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
   integrity sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
@@ -6767,19 +6767,6 @@ p-reduce@2.1.0, p-reduce@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
   integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
-
-p-reflect@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/p-reflect/-/p-reflect-2.1.0.tgz#5d67c7b3c577c4e780b9451fc9129675bd99fe67"
-  integrity sha512-paHV8NUz8zDHu5lhr/ngGWQiW067DK/+IbJ+RfZ4k+s8y4EKyYCz8pGYWjxCg35eHztpJAt+NUgvN4L+GCbPlg==
-
-p-settle@^4.0.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/p-settle/-/p-settle-4.1.1.tgz#37fbceb2b02c9efc28658fc8d36949922266035f"
-  integrity sha512-6THGh13mt3gypcNMm0ADqVNCcYa3BK6DWsuJWFCuEKP1rpY+OKGp7gaZwVmLspmic01+fsg/fN57MfvDzZ/PuQ==
-  dependencies:
-    p-limit "^2.2.2"
-    p-reflect "^2.1.0"
 
 p-timeout@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
## Summary
- replace `p-settle` usage in `@spencejs/spence-pg-repos` with native `Promise.allSettled`
- preserve the existing `insertMany` result shape by normalizing settled results to the current `{ isFulfilled, isRejected, value | reason }` contract
- remove `p-settle` from the package manifest and lockfile
- make the `insertMany` test assert the full settled object shape explicitly

## Why
`p-settle` 5.x is pure ESM, but `spence-pg-repos` is still CommonJS and imports it with `require(...)`. That makes the Dependabot PR unsafe as a straight dependency bump.

Using native `Promise.allSettled` removes the dependency entirely while keeping the current API behavior.

## Impact
- fixes the `p-settle` upgrade path without converting this package to ESM
- drops an unnecessary runtime dependency
- keeps callers of `insertMany` behaviorally compatible

## Validation
- `yarn install`
- attempted: `yarn workspace @spencejs/spence-pg-repos test test/pg-repos.test.js --runInBand --coverage=false --watchman=false`

## Verification gap
The targeted package test run is currently blocked by local environment setup: no reachable Postgres instance at `postgresql://postgres@localhost:5432/spence_test`, so the DB-backed tests fail during schema creation rather than from this change.
