### PR TITLE
[codex] tighten npm package contents

### DIFF
--- a/packages/spence-api/.npmignore
+++ b/packages/spence-api/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-test
-jest.config.js
-coverage

--- a/packages/spence-api/LICENSE
+++ b/packages/spence-api/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence-api/package.json
+++ b/packages/spence-api/package.json
@@ -3,6 +3,12 @@
   "version": "1.1.0",
   "main": "./src/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "src",
+    "types",
+    "spencerc.js",
+    "tsconfig.json"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/spence-config/.npmignore
+++ b/packages/spence-config/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-test
-jest.config.js
-coverage

--- a/packages/spence-config/LICENSE
+++ b/packages/spence-config/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence-config/package.json
+++ b/packages/spence-config/package.json
@@ -3,6 +3,11 @@
   "version": "1.1.0",
   "main": "src/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "src",
+    "types",
+    "tsconfig.json"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/spence-events/.npmignore
+++ b/packages/spence-events/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-test
-jest.config.js
-coverage

--- a/packages/spence-events/LICENSE
+++ b/packages/spence-events/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence-events/package.json
+++ b/packages/spence-events/package.json
@@ -3,6 +3,12 @@
   "version": "1.1.0",
   "main": "src/index.js",
   "types": "types/index.d.ts",
+  "files": [
+    "src",
+    "types",
+    "!types/**/*.test-d.ts",
+    "tsconfig.json"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/spence-factories/.npmignore
+++ b/packages/spence-factories/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-test
-jest.config.js
-coverage

--- a/packages/spence-factories/LICENSE
+++ b/packages/spence-factories/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence-factories/package.json
+++ b/packages/spence-factories/package.json
@@ -2,6 +2,12 @@
   "name": "@spencejs/spence-factories",
   "version": "1.1.0",
   "main": "src/factory.js",
+  "files": [
+    "src",
+    "types",
+    "spencerc.js",
+    "tsconfig.json"
+  ],
   "license": "MIT",
   "engines": {
     "node": ">=22.0.0"

--- a/packages/spence-mongo-repos/.npmignore
+++ b/packages/spence-mongo-repos/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-test
-jest.config.js
-coverage

--- a/packages/spence-mongo-repos/LICENSE
+++ b/packages/spence-mongo-repos/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence-mongo-repos/package.json
+++ b/packages/spence-mongo-repos/package.json
@@ -3,6 +3,11 @@
   "version": "1.1.0",
   "main": "./src/index.js",
   "types": "./types/index.d.ts",
+  "files": [
+    "src",
+    "types",
+    "tsconfig.json"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/spence-pg-repos/.npmignore
+++ b/packages/spence-pg-repos/.npmignore
@@ -1,4 +1,0 @@
-node_modules
-test
-jest.config.js
-coverage

--- a/packages/spence-pg-repos/LICENSE
+++ b/packages/spence-pg-repos/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence-pg-repos/package.json
+++ b/packages/spence-pg-repos/package.json
@@ -2,6 +2,10 @@
   "name": "@spencejs/spence-pg-repos",
   "version": "1.1.0",
   "main": "./src/index.js",
+  "files": [
+    "src",
+    "spencerc.js"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/spence/.npmignore
+++ b/packages/spence/.npmignore
@@ -1,3 +1,0 @@
-node_modules
-test
-jest.config.js

--- a/packages/spence/LICENSE
+++ b/packages/spence/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2015-present Spence Contributors
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/spence/package.json
+++ b/packages/spence/package.json
@@ -2,6 +2,9 @@
   "name": "@spencejs/spence",
   "version": "1.1.0",
   "main": "./src/index.js",
+  "files": [
+    "src"
+  ],
   "license": "MIT",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Summary

- Add explicit `files` allowlists to every published package so npm tarball contents are controlled by inclusion instead of exclusion.
- Add package-local MIT `LICENSE` files so direct package-level `npm pack` includes license text, matching what Lerna added during the `1.1.0` publish.
- Remove package `.npmignore` files because the new `files` allowlists make them redundant.

## Why

The `1.1.0` publish exposed packaging hygiene issues: generated artifacts leaked into published tarballs, including `reports/junit/lint-results.xml` and `yarn-error.log`. Using explicit `files` allowlists makes future package contents predictable and prevents test output, coverage, debug logs, tarballs, and type-test files from being published.

## Validation

- Ran `npm pack --dry-run --json` for all seven published packages.
- Verified each package includes `LICENSE`.
- Verified generated artifacts, tests, coverage, `node_modules`, debug logs, tarballs, and `*.test-d.ts` are excluded.
