### PR TITLE
chore: group Fastify Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -64,6 +64,17 @@
       ],
       "groupName": "test libraries",
       "groupSlug": "test-libraries"
+    },
+    {
+      "description": "Keep Fastify packages together.",
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "fastify**"
+      ],
+      "groupName": "Fastify packages",
+      "groupSlug": "fastify"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a dedicated Renovate package group for Fastify packages
- use explicit matching because Renovate does not provide a built-in Fastify package/group preset

## Verification
- pnpm dlx --package=renovate renovate-config-validator renovate.json